### PR TITLE
Update Arch Linux package URL in install.md

### DIFF
--- a/website/docs/install.md
+++ b/website/docs/install.md
@@ -78,7 +78,7 @@ Ubuntu and Debian users may use this apt repository: [https://packages.azlux.fr/
 
 ## Arch Linux
 
-Arch Linux users may use `pacman` to install [rhit](https://archlinux.org/packages/community/x86_64/rhit/) from the community repository:
+Arch Linux users may use `pacman` to install [rhit](https://archlinux.org/packages/extra/x86_64/rhit/) from the extra repository:
 
 ```bash
 pacman -S rhit


### PR DESCRIPTION
The old URL returns 404 now.